### PR TITLE
Work towards supporting 16-bit values for the storage-area

### DIFF
--- a/inter.z80
+++ b/inter.z80
@@ -97,79 +97,78 @@ MACRO POP_ALL
         pop af
       ENDM
 
+      ;
+      ; CP/M binaries start at 0x100
+      ;
+      ORG 0x100
 
-   ;
-   ; CP/M binaries start at 0x100
-   ;
-   ORG 0x100
-
-   ;
-   ; We can be built as a REPL, or as a test-driver.
-   ;
+      ;
+      ; We can be built as a REPL, or as a test-driver.
+      ;
 IF REPL
 
-   ;
-   ; REPL will prompt for input, and execute it, endlessly
-   ;
+      ;
+      ; REPL will prompt for input, and execute it, endlessly
+      ;
 repl_loop:
 
-   ; Fill input-buffer with NULL
-   ld hl, input_buffer+2
-   ld bc, 200
+      ; Fill input-buffer with NULL
+      ld hl, input_buffer+2
+      ld bc, 200
 repl_loop_reset:
-   ld (hl), 0x00
-   inc hl
-   djnz repl_loop_reset
+      ld (hl), 0x00
+      inc hl
+      djnz repl_loop_reset
 
-   ; The start of the prompt
-   ld a, 0x0a
-   call bios_output_character
-   ld a, 0x0d
-   call bios_output_character
-   ld a, '['
-   call bios_output_character
+      ; The start of the prompt
+      ld a, 0x0a
+      call bios_output_character
+      ld a, 0x0d
+      call bios_output_character
+      ld a, '['
+      call bios_output_character
 
-   ;
-   ; Show the I/O port
-   ;
-   ld hl, io_port
-   ld a, (hl)
-   ld h, 0x0
-   ld l, a
-   call DispHL
+      ;
+      ; Show the I/O port
+      ;
+      ld hl, io_port
+      ld a, (hl)
+      ld h, 0x0
+      ld l, a
+      call DisplayHLAsHex
 
-   ; The end of the prompt
-   ld a, ']'
-   call bios_output_character
-   ld a, '>'
-   call bios_output_character
+      ; The end of the prompt
+      ld a, ']'
+      call bios_output_character
+      ld a, '>'
+      call bios_output_character
 
 
-   ;
-   ; Read input - 200 bytes, starting at the input-buffer
-   ;
-   ld de, input_buffer
-   ld a, 200
-   ld (de),a
-   ld c, 0x0A
-   call 0x005
+      ;
+      ; Read input - 200 bytes, starting at the input-buffer
+      ;
+      ld de, input_buffer
+      ld a, 200
+      ld (de),a
+      ld c, 0x0A
+      call 0x005
 
-   ;
-   ; Print a newline
-   ;
-   ld a, 0x0A
-   call bios_output_character
+      ;
+      ; Print a newline
+      ;
+      ld a, 0x0A
+      call bios_output_character
 
-   ;
-   ; Now interpret the string
-   ;
-   ld hl, input_buffer + 2
-   call interpret
+      ;
+      ; Now interpret the string
+      ;
+      ld hl, input_buffer + 2
+      call interpret
 
-   ;
-   ; Repeat
-   ;
-   jr repl_loop
+      ;
+      ; Repeat
+      ;
+      jr repl_loop
 
 ELSE
 
@@ -420,7 +419,7 @@ print_stack:
         ld a, (hl)
         ld h, 0
         ld l, a
-        call DispHL
+        call DisplayHLAsHex
 
         ; newline after the output
         ld a, 0x0A
@@ -486,39 +485,39 @@ bios_output_string:
 
 
 ;
-; Display HL - a number
+; Display the contents of HL as a hexadecimal number.
 ;
-DispHL:
-	ld	bc,-10000
-	call	Num1
-	ld	bc,-1000
-	call	Num1
-	ld	bc,-100
-	call	Num1
-	ld	c,-10
-	call	Num1
-	ld	c,-1
-Num1:	ld	a,'0'-1
-Num2:	inc	a
-	add	hl,bc
-	jr	c,Num2
-	sbc	hl,bc
-
+DisplayHLAsHex:
         PUSH_ALL
-
-        ld e, a
-        call bios_output_character
-
-        POP_ALL
-	ret
-
-show_a_register:
-        PUSH_ALL
-        ld h,0
-	ld l,a
-	call DispHL
+        ld  c,h
+        call  output_8_bit_number
+        ld  c,l
+        call output_8_bit_number
         POP_ALL
         ret
+
+
+;;
+;; Display the 8-bit number stored in C in hex.
+;;
+output_8_bit_number:
+        ld  a,c
+        rra
+        rra
+        rra
+        rra
+        call  Conv
+        ld  a,c
+Conv:
+        and  $0F
+        add  a,$90
+        daa
+        adc  a,$40
+        daa
+        ld e, a
+        call bios_output_character
+        ret
+
 
 ;;
 ;; The string we interpret
@@ -528,11 +527,13 @@ sample_str:
         DB 0x00
 
 ;;
-;; Storage area for numbers which have been input.
+;; We allow a single number to be entered into the storage-area, and used
+;; for various purposes.  The value is copied here.
 ;;
-;; The maximum value is 0xFF
+;; The maximum value is 0xFFFF
 ;;
 tmp_store:
+        DB 0x00
         DB 0x00
 
 ;;

--- a/inter.z80
+++ b/inter.z80
@@ -36,9 +36,6 @@
 
 ;;; TODO
 ;;
-;;  - The temporary store allows only 8-bit values to be used.
-;;    If we wanted to allow RAM read/write we'd need to extend that.
-;;
 ;;  - Allow either stack operations, or the use of named variables
 ;;    - A single "temporary area" is too limiting.
 ;;
@@ -129,13 +126,11 @@ repl_loop_reset:
       call bios_output_character
 
       ;
-      ; Show the I/O port
+      ; Show the I/O port - 0x00-0xff
       ;
       ld hl, io_port
-      ld a, (hl)
-      ld h, 0x0
-      ld l, a
-      call DisplayHLAsHex
+      ld c, (hl)
+      call output_8_bit_number
 
       ; The end of the prompt
       ld a, ']'
@@ -254,9 +249,9 @@ interpret:
         ;; Is it a C?
         ;;
         cp 'c'
-        jr z, clear_stack
+        jp z, clear_stack
         cp 'C'
-        jr z, clear_stack
+        jp z, clear_stack
 
         ;;
         ;; Is it a X?
@@ -314,47 +309,98 @@ ENDIF
 
 
 ;;
-;; Digit - Called if the input contains a number
+;; Digit - Called if the input contains a number.
 ;;
-;; Inputs: A register contains the ASCII character
+;; Inputs:
+;;  - A register contains the ASCII character.
+;;  - HL register contains pointer to next character of input
+;;
 digit:
         PUSH_ALL
-        sub '0'
+
+        ; we're called with the numerical digit in A,
+        ; and the address of the NEXT digit stored in HL
+        ;
+        ; We're going to cheat and use a routine that wants to
+        ; read the start of the string
+        dec hl
+
+        push hl
+        pop de
+
+        call atoui_16
+
+        ; hl has the result
+        push hl
+        pop bc
+
+        ; DE points to the value after
+        ld hl, xx
+        ld (hl),d
+        inc hl
+        ld (hl), e
+
+        ; save the value
         ld hl, tmp_store
-        push af
+        ld (hl), b
+        inc hl
+        ld (hl), c
 
-        ; store *= 10
-        ld b, (hl)
-        ld c, 10
-        call multiply
 
-        pop af
-        ; now add the new digit
-        add a,l
-
-        ; save the result
-        ld hl, tmp_store
-        ld (hl),a
         POP_ALL
+
+        ld hl,xx
+        ld a, (hl)
+        inc hl
+        ld l, (hl)
+        ld h, a
         jp interpret
 
+xx:
+        DB 0x00
+        DB 0x00
 
-
-; INPUT: THE VALUES IN REGISTER B EN C
-; OUTPUT: HL = B * C
-; CHANGES: AF,DE,HL,B
-;
-multiply:
-	LD HL,0
-	LD A,B
-	OR A
-	RET Z
-	LD D,0
-	LD E,C
-LOOP:	ADD HL,DE
-	DJNZ LOOP
-	RET
-
+string_to_uint16:
+atoui_16:
+;Input:
+;     DE points to the string
+;Outputs:
+;     HL is the result
+;     A is the 8-bit value of the number
+;     DE points to the byte after the number
+;Destroys:
+;     BC
+;       if the string is non-empty, BC is HL/10
+;Size:  24 bytes
+;Speed: 42+d(104+{0,9})
+;       d is the number of digits in the number
+;       max is 640 cycles for a 5 digit number
+;Assuming no leading zeros:
+;1 digit:  146cc
+;2 digit:  250cc
+;3 digit:  354cc or 363cc (avg: 354.126cc)
+;4 digit:  458cc or 467cc (avg: 458.27cc)
+;5 digit:  562cc or 571cc or 580cc (avg: 562.4104cc)
+;avg: 544.81158447265625cc (544+13297/16384)
+;===============================================================
+  ld hl,0
+_:
+  ld a,(de)
+  sub 30h
+  cp 10
+  ret nc
+  inc de
+  ld b,h
+  ld c,l
+  add hl,hl
+  add hl,hl
+  add hl,bc
+  add hl,hl
+  add a,l
+  ld l,a
+  jr nc,_
+  inc h
+  jp _
 
 ;;
 ;; Called if we've got a C in the input; clear the temporary store
@@ -362,6 +408,8 @@ LOOP:	ADD HL,DE
 clear_stack:
         PUSH_ALL
         ld hl, tmp_store
+        ld (hl), 0x00
+        inc hl
         ld (hl), 0x00
         POP_ALL
         jp interpret
@@ -382,6 +430,8 @@ io_port_in:
 
         ; store
         ld hl, tmp_store
+        ld (hl), 0x0
+        inc hl
         ld (hl),a
         POP_ALL
         jp interpret
@@ -399,7 +449,7 @@ io_port_out:
         ld c, (hl)
 
         ; get the value to write
-        ld hl, tmp_store
+        ld hl, tmp_store+1
         ld a, (hl)
 
         ; write
@@ -417,8 +467,9 @@ print_stack:
         PUSH_ALL
         ld hl, tmp_store
         ld a, (hl)
-        ld h, 0
-        ld l, a
+        inc hl
+        ld l, (hl)
+        ld h, a
         call DisplayHLAsHex
 
         ; newline after the output
@@ -436,7 +487,7 @@ print_stack:
 ;;
 io_port_set:
         PUSH_ALL
-        ld hl, tmp_store
+        ld hl, tmp_store+1
         ld a, (hl)
         ld hl, io_port
         ld (hl),a
@@ -496,6 +547,40 @@ DisplayHLAsHex:
         POP_ALL
         ret
 
+
+;;
+;; Read the two-digit HEX number from HL, and convert to an integer
+;; stored in the A-register.
+;;
+;; HL will be incremented twice.
+;;
+read_8_bit_ascii_number:
+	ld		a, (hl)
+        ;; is it lower-case?  If so upper-case it.
+        cp 'a'
+        jr c, read_8_bit_ascii_number_uc
+        cp 'z'
+        jr nc, read_8_bit_ascii_number_uc
+        sub 32
+read_8_bit_ascii_number_uc:
+        call		read_8_bit_ascii_number_hex
+        add		a, a
+        add		a, a
+        add		a, a
+        add		a, a
+        ld		d, a
+	inc		hl
+        ld		a, (hl)
+        call		read_8_bit_ascii_number_hex
+        or		d
+	inc		hl
+        ret
+read_8_bit_ascii_number_hex:
+        sub		'0'
+        cp		10
+        ret		c
+        sub		'A'-'0'-10
+        ret
 
 ;;
 ;; Display the 8-bit number stored in C in hex.


### PR DESCRIPTION
This pull request, once complete, will support 16-bit values being input and output from the storage-area.

Currently I've reworked the output to show the contents of the area as 4-byte hex values, and allowed arbitrary input in decimal.

So we'll expect to allow the user to enter each of the following statements:

* 3#
* 33#
* 322#
* 1024#
* 65534#

The outstanding task here is to overhaul the setup so that we can allow HEX input, to match the HEX output.  (Though decimal is still OK).

Once complete this will close #1.