### PR TITLE
Split opcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is a trivial REPL-based "scripting thing", designed to run on Z80-based CP/M systems.
 
-The REPL allows arbitrary I/O to ports, and RAM, but little else - for usefulness the currently-selected I/O port is displayed in the REPL prompt.
+The REPL allows arbitrary I/O to ports, and RAM, along with string output and looping-support, but there is little else - for usefulness the currently-selected I/O port is displayed in the REPL prompt.
 
-All-told the interpreter, when compiled as REPL, takes less than 750 bytes.
+All-told the interpreter, when compiled as REPL, requires approximately 800 bytes.
 
 
 
@@ -15,11 +15,11 @@ This repository contains a simple REPL-based interpreter which will run upon a C
 There are three registers which are used, internally:
 
 * Any time a number is encountered it is moved into a scratch-area.
-  * This is notionally the accumulator register.
-* It is possible to move the accumulator value into the IO-register.
+  * This is notionally known as the accumulator register.
+* It is possible to move the accumulator value into the IO-register, `#`.
   * This register contains the port-number that any I/O read, or write, operation is applied to.
 * It is possible to move the accumulator value into the memory-register, M.
-  * This register contains the RAM address of any memory read/write operations.
+  * This register specifies the RAM address of any memory read/write operations.
 * Finally you may move the contents of the accumulator into the K-register, which is used for operating loops.
 
 TLDR:
@@ -38,6 +38,8 @@ The following instructions are available:
   * Build up a number, which is stored in the temporary area.
 * `[ \t\n]`
   * Ignored.
+* `{..}`
+  * Looping construct, see below for details.
 * `#`
   * Set the I/O-port to be the value of the accumulator.
 * `_`
@@ -57,6 +59,8 @@ The following instructions are available:
   * Copy the contents of the K-register to the accumulator.
 * `m`
   * Write the contents of the accumulator to the currently selected RAM address (in the M-register).
+* `n`
+  * Write a newline character.
 * `o`
   * Write the contents of the accumulator to the currently selected I/O port (held in the #-register).
 * `p`
@@ -73,6 +77,36 @@ The following instructions are available:
   * Then increment the RAM address held in the M-register (so that repeats will write to incrementing addresses).
 * `x`
   * Print the character whos ASCII code is stored in the accumulator.
+
+
+
+## Looping
+
+The special K-register can be used to control how many times a loop will be carried out.
+
+Loops consist of code between `{` and `}` pairs.  For example the following program will show a countdown:
+
+```
+[00]>10k{Kp}
+0009
+0008
+0007
+0006
+0005
+0004
+0003
+0002
+0001
+0000
+```
+
+First of all the value 10 is loaded into the accumulator, then copied into the K-register.  The body of the loop is then:
+
+```
+Kp
+```
+
+K copies the contents of the loop-register back to the accumulator, which is then printed by the `p` command.
 
 
 ### Sample "Programs"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The following instructions are available:
   * Ignored.
 * `#`
   * Set the I/O-port to be the value of the accumulator.
+* `_`
+  * Print the string wrapped by by "_" characters.
 * `c`
   * Clear the number in the accumulator.  (i.e. Set to zero).
 * `g`
@@ -78,6 +80,12 @@ The following instructions are available:
 > Note: In these examples I've prefixed "c" to the input, this clears the state of the temporary storage area - which isn't necessary if you run them immediately upon startup, but will avoid surprises otherwise.
 
 Also note that I broke up the "programs" with whitespace to aid readability.  This still works, spaces, TABs, and newlines are skipped over by the interpreter.
+
+Show a greeting:
+
+```
+_Hello, world!_
+```
 
 Store the value 42 in the temporary storage area, and print it:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following instructions are available:
 * `[ \t\n]`
   * Ignored.
 * `#`
-  * Set I/O to use the port in the storage-area.
+  * Set the I/O-port to be the value of the accumulator.
 * `c`
   * Clear the number in the accumulator.  (i.e. Set to zero).
 * `g`
@@ -49,12 +49,18 @@ The following instructions are available:
   * This is used for running delay operations.
 * `i`
   * Read a byte of input, from the currently selected I/O port (#-register), and place it in the accumulator.
+* `k`
+  * Copy the contents of the accumulator (lower half) into the K-register.
+* `K`
+  * Copy the contents of the K-register to the accumulator.
 * `m`
   * Write the contents of the accumulator to the currently selected RAM address (in the M-register).
 * `o`
   * Write the contents of the accumulator to the currently selected I/O port (held in the #-register).
 * `p`
-  * Print the value of the accumulator.
+  * Print the value of the accumulator, as a four-digit hex number.
+* `P`
+  * Print the value of the lower half of the accumulator, as a two-digit hex number.
 * `r`
   * Read the contents of the currently selected RAM address, held in the M-register), and save in the accumulator.
   * Then increment the RAM address held in the M-register (so that repeats will read from incrementing addresses).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ There are three registers which are used, internally:
 
 * Any time a number is encountered it is moved into a scratch-area.
   * This is notionally known as the accumulator register.
-* It is possible to move the accumulator value into the IO-register, `#`.
+* It is possible to move the accumulator value into the IO-register, U.
   * This register contains the port-number that any I/O read, or write, operation is applied to.
+  * Not a great mnemonic, but close to both I&O on the keyboard.
 * It is possible to move the accumulator value into the memory-register, M.
   * This register specifies the RAM address of any memory read/write operations.
 * Finally you may move the contents of the accumulator into the K-register, which is used for operating loops.
@@ -25,7 +26,7 @@ There are three registers which are used, internally:
 TLDR:
 
 * Numbers go to A-Register.
-* Port I/O is controlled by the #-register.
+* Port I/O is controlled by the U-register.
 * RAM read/write is controlled by the M-register.
 * Loops are controlled by the K-register.
 
@@ -40,8 +41,10 @@ The following instructions are available:
   * Ignored.
 * `{..}`
   * Looping construct, see below for details.
-* `#`
+* `u`
   * Set the I/O-port to be the value of the accumulator.
+* `U`
+  * Set the accumulator to be the value of the I/O-port.
 * `_`
   * Print the string wrapped by by "_" characters.
 * `c`
@@ -52,7 +55,7 @@ The following instructions are available:
   * HALT for the number of times specified in the storage-area.
   * This is used for running delay operations.
 * `i`
-  * Read a byte of input, from the currently selected I/O port (#-register), and place it in the accumulator.
+  * Read a byte of input, from the currently selected I/O port (U-register), and place it in the accumulator.
 * `k`
   * Copy the contents of the accumulator (lower half) into the K-register.
 * `K`
@@ -62,7 +65,7 @@ The following instructions are available:
 * `n`
   * Write a newline character.
 * `o`
-  * Write the contents of the accumulator to the currently selected I/O port (held in the #-register).
+  * Write the contents of the accumulator to the currently selected I/O port (held in the U-register).
 * `p`
   * Print the value of the accumulator, as a four-digit hex number.
 * `P`
@@ -144,24 +147,24 @@ c 42 x
 Configure the I/O port to be port 0x01, read a byte from it to the temporary storage area, then print that value:
 
 ```
-c 1 # i p
+c 1 u i p
 ```
 
 Write the byte 32, then the byte 77, to the I/O port 3.
 
 ```
-c 3 # c 32 o c 77 o
+c 3 u c 32 o c 77 o
 ```
 
 To be more explicit that last example could have been written as:
 
-* `c3#c32oc77o`
-  * `c3` - Clear the storage area, and write the number 3 to it.
-  * `#` - Set the I/O port to be used for (i)nput and (o)utput to be the value in the temporary storage-area, i.e. 3.
-  * `c32` - Clear the storage area, and write the number 32 to it.
-  * `o` - Output the byte in the storage area (32) to the currently selected I/O port (3)
-  * `c77` - Clear the storage area, and write the number 77 to it.
-  * `o` - Output the byte in the storage area (77) to the currently selected I/O port (3)
+* `c3uc32oc77o`
+  * `c3` - Clear the accumulator, and write the number 3 to it.
+  * `u` - Set the I/O port to be used for (i)nput and (o)utput to be the value in the accumulator, i.e. 3.
+  * `c32` - Clear the accumulator, and write the number 32 to it.
+  * `o` - Output the byte in the accumulator (32) to the currently selected I/O port (3)
+  * `c77` - Clear the accumulator, and write the number 77 to it.
+  * `o` - Output the byte in the accumulator (77) to the currently selected I/O port (3)
 
 
 

--- a/inter.z80
+++ b/inter.z80
@@ -33,6 +33,7 @@
 ;;   k:  Copy the accumulator to the k-register.
 ;;   K:  Copy the k-register to the accumulator.
 ;;   m:  Set the memory address to read/write to from the contents of the temporary storage area
+;;   n:  Write a newline.
 ;;   o:  Write the contents of the storage-area to the I/O port selected.
 ;;   p:  Print the four-digit value held in the accumulator.
 ;;   P:  Print the two-digit value held in the lower half of the accumulator.
@@ -54,8 +55,6 @@
 ;;  - Add "+", "-", etc.
 ;;
 ;;  - Allow conditionals of some kind.  []
-
-;;  - Allow loops, using the k-register. {}
 ;;
 
 ;;; Sample code
@@ -263,6 +262,12 @@ interpret:
         jp z, ram_set
 
         ;;
+        ;; Write a newline
+        ;;
+        cp 'n'
+        jp z, output_newline
+
+        ;;
         ;; Is it an O?
         ;;
         cp 'o'
@@ -340,6 +345,11 @@ interpret:
         ;; is this a loop?
         cp '{'
         jp z, k_register_loop
+
+        ;; is this the end of a loop?
+        cp '}'
+        jp z, k_register_loop_again
+
 
         ;; If we got here we found a character we can't understand
         ;; Show that, and abort
@@ -607,6 +617,14 @@ io_port_in:
         jp interpret
 
 ;;
+;; Called via 'n', which writes a newline
+;;
+output_newline:
+        ld a, 0x0A
+        call bios_output_character
+        jp interpret
+
+;;
 ;; Called if we've got an O in the input, perform an I/O write.
 ;;
 ;; The temporary storage area will have the byte to write.
@@ -640,10 +658,6 @@ print_accumulator_full:
         ld h, a
         call DisplayHLAsHex
 
-        ; newline after the output
-        ld a, 0x0A
-        call bios_output_character
-
         POP_ALL
         jp interpret
 
@@ -654,10 +668,6 @@ print_accumulator_bottom:
         ld hl, tmp_store+1
         ld c, (hl)
         call output_8_bit_number
-
-        ; newline after the output
-        ld a, 0x0A
-        call bios_output_character
 
         POP_ALL
         jp interpret
@@ -755,29 +765,20 @@ k_register_loop:
         cp 0
         jr z, loop_time_over
 
-        ;; handle loop-body
-        ;;  Decrease K
+        ;;  Decrease K - so that the iteration will eventually end.
         push hl
         ld hl,k_register
         dec (hl)
         pop hl
 
-        ;;  Run the loop-body
-        ;;    - By copying to a backup input buffer.
-        push hl
-
-        ;;; HL points to the loop body
-        ;;; Copy to input_loop
-        ;;; Until we hit }
-        ;;; CALL interpreter
-        ;;;
-
-        pop hl
-
-        ;; Go back to the start of the loop.
-        dec hl
+        ;; Now we're inside the loop-body, and we want to run it.
+        ;; so we can just jump back to the interpreter.
         jp interpret
 
+
+        ;; Skip the loop, by going forward to the closing character
+        ;;
+        ;; TODO / FIXME: We could count open braces to allow nested loops...
 loop_time_over:
         ld a, (hl)
         inc hl
@@ -785,6 +786,21 @@ loop_time_over:
         jp z, interpret
         jr loop_time_over
 
+
+;;
+;; Called at loop-close time, when a } is seen
+;;
+;; We have HL pointing to the character after the loop, and we
+;; want to change it to point back to the start of the loop.
+;;
+;; TODO / FIXME: We could count brace-pairs to allow nested loops
+;;
+k_register_loop_again:
+        ld a, (hl)
+        cp '{'
+        jp z, interpret
+        dec hl
+        jr k_register_loop_again
 
 ;;
 ;; Called when we see "_hello, world_"
@@ -870,7 +886,7 @@ output_8_bit_number:
         rra
         rra
         rra
-        call  Conv
+        call Conv
         ld  a,c
 Conv:
         and  $0F

--- a/inter.z80
+++ b/inter.z80
@@ -25,22 +25,22 @@
 ;;; Valid inputs:
 ;;
 ;; 0-9:  Build up a number
-;;   #:  Set I/O to use the port in the storage-area
-;;   c:  Clear the number in the storage-area
-;;   i:  Read a byte of input, from the selected I/O port, and place it in the storage-area
+;;   #:  Set the I/O register to be the contents of the accumulator.
+;;   c:  Clear the accumulator.
+;;   i:  Read a byte of input, from the selected I/O port, and place it in the accumulator.
 ;;   g:  Read the stored value of the memory address, and CALL it.
-;;   h:  Halt for the number of times specified in the storage-area.
+;;   h:  Halt for the number of times specified in the accumulator.
 ;;   k:  Copy the accumulator to the k-register.
 ;;   K:  Copy the k-register to the accumulator.
-;;   m:  Set the memory address to read/write to from the contents of the temporary storage area
+;;   m:  Set the memory address to read/write to from the contents of the accumulator.
 ;;   n:  Write a newline.
-;;   o:  Write the contents of the storage-area to the I/O port selected.
+;;   o:  Write the contents of the accumulator to the I/O port selected.
 ;;   p:  Print the four-digit value held in the accumulator.
 ;;   P:  Print the two-digit value held in the lower half of the accumulator.
 ;;   q:  Quit, if we're in REPL-mode
 ;;   r:  Read the contents of the memory-address, and place in the storage area.
 ;;   w:  Write the contents of the storage-area (byte) to the selected memory address.
-;;   x:  Print the character whos ASCII code is stored in the storage-area
+;;   x:  Print the character whos ASCII code is stored in the accumulator.
 ;;   _:  Print the string contained between "_" and "_".
 ;; " ":  Whitespace is skipped over
 ;;
@@ -48,6 +48,8 @@
 ;;
 
 ;;; TODO
+;;
+;;  - Nested loops wouldn't be impossible.
 ;;
 ;;  - Allow either stack operations, or the use of named variables
 ;;    - A single "temporary area" is too limiting.
@@ -136,10 +138,7 @@ repl_loop_reset_input:
       djnz repl_loop_reset_input
 
       ; The start of the prompt
-      ld a, 0x0a
-      call bios_output_character
-      ld a, 0x0d
-      call bios_output_character
+      call output_newline
       ld a, '['
       call bios_output_character
 
@@ -166,8 +165,7 @@ repl_loop_reset_input:
       ;
       ; Print a newline
       ;
-      ld a, 0x0A
-      call bios_output_character
+      call output_newline
 
       ;
       ; Now interpret the string
@@ -265,8 +263,12 @@ interpret:
         ;; Write a newline
         ;;
         cp 'n'
-        jp z, output_newline
+        jp nz, not_output_newline
 
+        call output_newline
+        jr interpret
+
+not_output_newline:
         ;;
         ;; Is it an O?
         ;;
@@ -622,7 +624,9 @@ io_port_in:
 output_newline:
         ld a, 0x0A
         call bios_output_character
-        jp interpret
+        ld a, 0x0D
+        call bios_output_character
+        ret
 
 ;;
 ;; Called if we've got an O in the input, perform an I/O write.
@@ -903,10 +907,10 @@ Conv:
 include "bios.z80"
 
 ;;
-;; The string we interpret
+;; The string we interpret when not in REPL mode.
 ;;
 sample_str:
-        DB "p c123pc42xxxxc72xc73xc10xc72xc73xc10x"
+        DB "10k{Kp_ OK!_n}"
         DB 0x00
 
 ;;

--- a/inter.z80
+++ b/inter.z80
@@ -40,6 +40,7 @@
 ;;   r:  Read the contents of the memory-address, and place in the storage area.
 ;;   w:  Write the contents of the storage-area (byte) to the selected memory address.
 ;;   x:  Print the character whos ASCII code is stored in the storage-area
+;;   _:  Print the string contained between "_" and "_".
 ;; " ":  Whitespace is skipped over
 ;;
 ;; All other inputs are ignored.
@@ -52,7 +53,9 @@
 ;;
 ;;  - Add "+", "-", etc.
 ;;
-;;  - Allow conditionals, or loops, of some kind.
+;;  - Allow conditionals of some kind.  []
+
+;;  - Allow loops, using the k-register. {}
 ;;
 
 ;;; Sample code
@@ -321,6 +324,10 @@ interpret:
         ;; Is this an I/O port flag?
         cp '#'
         jp z, io_port_set
+
+        ;; Is this string output?
+        cp '_'
+        jp z, string_output
 
         ;; Is this an K-register set?
         cp 'k'
@@ -720,6 +727,19 @@ k_register_get:
         POP_ALL
         jp interpret
 
+;;
+;; Called when we see "_hello, world_"
+;;
+string_output:
+        ld a,(hl)
+        cp '_'
+        jr z, string_output_over
+        call bios_output_character
+        inc hl
+        jr string_output
+string_output_over:
+        inc hl
+        jp interpret
 
 ;;
 ;; called if we've got an X in the input
@@ -728,7 +748,7 @@ k_register_get:
 ;;
 output_stack_char:
         PUSH_ALL
-        ld hl, tmp_store
+        ld hl, tmp_store+1
         ld a, (hl)
         call bios_output_character
         POP_ALL

--- a/inter.z80
+++ b/inter.z80
@@ -329,8 +329,10 @@ not_output_newline:
         jr z, digit
 
         ;; Is this an I/O port flag?
-        cp '#'
+        cp 'u'
         jp z, io_port_set
+        cp 'U'
+        jp z, io_port_get
 
         ;; Is this string output?
         cp '_'
@@ -703,15 +705,29 @@ delay_operation_loop:
 
 
 ;;
-;; Called if we've been given "#" in the input.
+;; Called if we've been given "u" in the input.
 ;;
-;; Update the current I/O port, with the contents of the storage-area
+;; Update the current I/O port, with the contents of the accumulator.
 ;;
 io_port_set:
         PUSH_ALL
         ld hl, tmp_store+1
         ld a, (hl)
         ld hl, io_port
+        ld (hl),a
+        POP_ALL
+        jp interpret
+
+;;
+;; Called if we've been given "U", copy the U-register to the accumulator.
+;;
+io_port_get:
+        PUSH_ALL
+        ld hl, io_port
+        ld a,(hl)
+        ld hl, tmp_store
+        ld (hl), 0
+        inc hl
         ld (hl),a
         POP_ALL
         jp interpret

--- a/inter.z80
+++ b/inter.z80
@@ -337,6 +337,10 @@ interpret:
         cp 'K'
         jp z, k_register_get
 
+        ;; is this a loop?
+        cp '{'
+        jp z, k_register_loop
+
         ;; If we got here we found a character we can't understand
         ;; Show that, and abort
         ld de, error_character_msg
@@ -726,6 +730,61 @@ k_register_get:
         ld (hl),a
         POP_ALL
         jp interpret
+
+;;
+;; Called to handle a loop.
+;;
+k_register_loop:
+        ;;
+        ;; Given input "4k{_Hello ...}"
+        ;;
+        ;; HL points to the character after the loop-start so "_" in our case.
+        ;;
+        ;; If the value of the K register is zero we move HL to the
+        ;; value after } and return.
+        ;;
+        ;; Otherwise we decrement K-register, and have to run the sub-body.
+        ;;
+        ;; NOTE: No nesting of loops
+        ;;
+        push hl
+        ld hl, k_register
+        ld a,(hl)
+        pop hl
+
+        cp 0
+        jr z, loop_time_over
+
+        ;; handle loop-body
+        ;;  Decrease K
+        push hl
+        ld hl,k_register
+        dec (hl)
+        pop hl
+
+        ;;  Run the loop-body
+        ;;    - By copying to a backup input buffer.
+        push hl
+
+        ;;; HL points to the loop body
+        ;;; Copy to input_loop
+        ;;; Until we hit }
+        ;;; CALL interpreter
+        ;;;
+
+        pop hl
+
+        ;; Go back to the start of the loop.
+        dec hl
+        jp interpret
+
+loop_time_over:
+        ld a, (hl)
+        inc hl
+        cp '}'
+        jp z, interpret
+        jr loop_time_over
+
 
 ;;
 ;; Called when we see "_hello, world_"

--- a/inter.z80
+++ b/inter.z80
@@ -30,9 +30,12 @@
 ;;   i:  Read a byte of input, from the selected I/O port, and place it in the storage-area
 ;;   g:  Read the stored value of the memory address, and CALL it.
 ;;   h:  Halt for the number of times specified in the storage-area.
+;;   k:  Copy the accumulator to the k-register.
+;;   K:  Copy the k-register to the accumulator.
 ;;   m:  Set the memory address to read/write to from the contents of the temporary storage area
 ;;   o:  Write the contents of the storage-area to the I/O port selected.
-;;   p:  Print the number in the storage-area
+;;   p:  Print the four-digit value held in the accumulator.
+;;   P:  Print the two-digit value held in the lower half of the accumulator.
 ;;   q:  Quit, if we're in REPL-mode
 ;;   r:  Read the contents of the memory-address, and place in the storage area.
 ;;   w:  Write the contents of the storage-area (byte) to the selected memory address.
@@ -266,7 +269,9 @@ interpret:
         ;; Is it a P?
         ;;
         cp 'p'
-        jp z, print_stack
+        jp z, print_accumulator_full
+        cp 'P'
+        jp z, print_accumulator_bottom
 
         ;;
         ;; Q will quit
@@ -316,6 +321,14 @@ interpret:
         ;; Is this an I/O port flag?
         cp '#'
         jp z, io_port_set
+
+        ;; Is this an K-register set?
+        cp 'k'
+        jp z, k_register_set
+
+        ;; Is this an K-register get?
+        cp 'K'
+        jp z, k_register_get
 
         ;; If we got here we found a character we can't understand
         ;; Show that, and abort
@@ -605,11 +618,9 @@ io_port_out:
 
 ;;
 ;; Called if we've got a P in the input; show the contents of the temporary
-;; store, as decimal number.
+;; store, as a four-digit hex number.
 ;;
-;; NOTE: Shows five digits..
-;;
-print_stack:
+print_accumulator_full:
         PUSH_ALL
         ld hl, tmp_store
         ld a, (hl)
@@ -617,6 +628,21 @@ print_stack:
         ld l, (hl)
         ld h, a
         call DisplayHLAsHex
+
+        ; newline after the output
+        ld a, 0x0A
+        call bios_output_character
+
+        POP_ALL
+        jp interpret
+
+
+;;
+print_accumulator_bottom:
+        PUSH_ALL
+        ld hl, tmp_store+1
+        ld c, (hl)
+        call output_8_bit_number
 
         ; newline after the output
         ld a, 0x0A
@@ -661,6 +687,35 @@ io_port_set:
         ld hl, tmp_store+1
         ld a, (hl)
         ld hl, io_port
+        ld (hl),a
+        POP_ALL
+        jp interpret
+
+
+;;
+;; Called if we've been given "k", copy the accumulator into the k-register
+;;
+k_register_set:
+        PUSH_ALL
+        ld hl, tmp_store+1
+        ld a, (hl)
+        ld hl, k_register
+        ld (hl),a
+        POP_ALL
+        jp interpret
+
+
+
+;;
+;; Called if we've been given "K", copy the k-register to the accumulator.
+;;
+k_register_get:
+        PUSH_ALL
+        ld hl, k_register
+        ld a,(hl)
+        ld hl, tmp_store
+        ld (hl), 0
+        inc hl
         ld (hl),a
         POP_ALL
         jp interpret
@@ -774,6 +829,14 @@ tmp_store:
 ;;
 io_port:
         DB 0x00
+
+
+;;
+;; K-register is used for loop operations.
+;;
+k_register:
+        DB 0x00
+
 
 
 ;;


### PR DESCRIPTION
This pull-request makes a bunch of changes but the main aim was to bring in case-sensitivity.

Since we have a notion of special registers (I/O, RAM, Loop) it makes sense to allow them to be both get and set.  So we use the lower-case character to set them, and the upper-case to get.

We've also introduced the notion of loops, which can't be nested yet, and documented things a little more :)